### PR TITLE
Add PHP example demonstrating OOP principles

### DIFF
--- a/oop_principles.php
+++ b/oop_principles.php
@@ -1,0 +1,48 @@
+<?php
+// Ví dụ minh họa 4 tính chất của lập trình hướng đối tượng (OOP) trong PHP
+// 1. Tính đóng gói (Encapsulation)
+// 2. Tính kế thừa (Inheritance)
+// 3. Tính đa hình (Polymorphism)
+// 4. Tính trừu tượng (Abstraction)
+
+abstract class Animal {
+    // Đóng gói: thuộc tính chỉ truy cập thông qua getter
+    private $name;
+
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+
+    public function getName(): string {
+        return $this->name;
+    }
+
+    // Trừu tượng: phương thức phải được lớp con cài đặt
+    abstract public function makeSound(): string;
+}
+
+// Kế thừa: Dog mở rộng Animal
+class Dog extends Animal {
+    public function makeSound(): string {
+        return "Gâu gâu";
+    }
+}
+
+// Kế thừa: Cat mở rộng Animal
+class Cat extends Animal {
+    public function makeSound(): string {
+        return "Meo meo";
+    }
+}
+
+// Hàm sử dụng đa hình: có thể nhận bất kỳ đối tượng Animal nào
+function describe(Animal $animal): void {
+    echo $animal->getName() . ': ' . $animal->makeSound() . PHP_EOL;
+}
+
+$dog = new Dog('Chó');
+$cat = new Cat('Mèo');
+
+describe($dog);
+describe($cat);
+?>


### PR DESCRIPTION
## Summary
- add `oop_principles.php` to show encapsulation, inheritance, polymorphism, and abstraction in PHP

## Testing
- `php oop_principles.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be148df4083319730d0341758dc31